### PR TITLE
minor correction in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 WebSocket.IO
 ============
 
@@ -59,7 +58,7 @@ var ws = require('websocket.io')
   , server = new ws.Server()
 
 // … somewhere in your http server code
-req.on('upgrade', function (req, socket, head) {
+server.on('upgrade', function (req, socket, head) {
   server.handleUpgrade(req, socket, head);
 });
 ```


### PR DESCRIPTION
In "Passing in requests" code example it should be server.on('upgrade' instead of req.on('upgrade'
