### PR TITLE
Typo in Socket.prototype.destroy

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -111,7 +111,7 @@ Socket.prototype.close = Socket.prototype.end = function () {
 
 Socket.prototype.destroy = function () {
   if (this.open) {
-    this.socket.detroy();
+    this.socket.destroy();
     this.onClose();
   }
   return this;


### PR DESCRIPTION
There is a typo in Socket.prototype.destroy, "detroy" is called instead of "destroy".
