### PR TITLE
Without this, I can't install websocket.io and require it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       , "colors": "*"
       , "benchmark": "0.2.2"
     }
+  , "main": "lib/websocket.io"
   , "engines": { "node": ">= 0.5.0 < 0.7.0" }
   , "scripts": {
         "test": "make test"


### PR DESCRIPTION
I downloaded the websocket.io and installed it globally and linked locally, but could not require('websocket.io') as the documentation said.

So I added lib/websocket.io.js in main section of package.json and it worked.

Please, see if it's ok.
