### PR TITLE
Use newer versions of ws

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       , { "name": "Arnout Kazemier", "email": "info@3rd-eden.com" }
     ]
   , "dependencies": {
-      "ws": "0.4.0"
+      "ws": ">=0.4.0"
   }
   , "devDependencies": {
         "mocha": "*"


### PR DESCRIPTION
Is there a reason you require ws 0.4.0 and not >=0.4.0? ws 0.4.3 fixes some resource leakage while the API stays the same.
