### PR TITLE
Method writeUInt16BE missing in Node 0.4

### DIFF
--- a/lib/protocols/hybi-07-12.js
+++ b/lib/protocols/hybi-07-12.js
@@ -199,12 +199,12 @@ WebSocket.prototype.frame = function (opcode, str) {
 
   switch (secondByte) {
     case 126:
-      outputBuffer.writeUInt16BE(dataLength, 2);
+      util.writeUInt16BE.call(outputBuffer, dataLength, 2);
       break;
 
     case 127:
-      outputBuffer.writeUInt32BE(0, 2);
-      outputBuffer.writeUInt32BE(dataLength, 6);
+      util.writeUInt32BE.call(outputBuffer, 0, 2);
+      util.writeUInt32BE.call(outputBuffer, dataLength, 6);
   }
 
   return outputBuffer;

--- a/lib/protocols/hybi-16.js
+++ b/lib/protocols/hybi-16.js
@@ -202,12 +202,12 @@ WebSocket.prototype.frame = function (opcode, str) {
 
   switch (secondByte) {
     case 126:
-      outputBuffer.writeUInt16BE(dataLength, 2);
+      util.writeUInt16BE.call(outputBuffer, dataLength, 2);
       break;
 
     case 127:
-      outputBuffer.writeUInt32BE(0, 2);
-      outputBuffer.writeUInt32BE(dataLength, 6);
+      util.writeUInt32BE.call(outputBuffer, 0, 2);
+      util.writeUInt32BE.call(outputBuffer, dataLength, 6);
   }
 
   return outputBuffer;

--- a/lib/util.js
+++ b/lib/util.js
@@ -48,3 +48,28 @@ exports.padl = function (s,n,c) {
   return new Array(1 + n - s.length).join(c) + s;
 }
 
+/**
+ * Writes value to the buffer at the specified offset with specified endian format.
+ * Note, value must be a valid unsigned 16 bit integer.
+ *
+ * @api public
+ */
+
+exports.writeUInt16BE = function (value, offset) {
+  this[offset] = (value & 0xff00)>>8;
+  this[offset+1] = value & 0xff;
+}
+
+/**
+ * Writes value to the buffer at the specified offset with specified endian format.
+ * Note, value must be a valid unsigned 32 bit integer.
+ *
+ * @api public
+ */
+
+exports.writeUInt32BE = function (value, offset) {
+  this[offset] = (value & 0xff000000)>>24;
+  this[offset+1] = (value & 0xff0000)>>16;
+  this[offset+2] = (value & 0xff00)>>8;
+  this[offset+3] = value & 0xff;
+}


### PR DESCRIPTION
This is taken from the ws module, they also seem to workaround this like that.
