### PR TITLE
Missing "protocol" header for HyBi connections

### DIFF
--- a/lib/protocols/hybi-07-12.js
+++ b/lib/protocols/hybi-07-12.js
@@ -123,6 +123,11 @@ WebSocket.prototype.onOpen = function () {
     , 'Sec-WebSocket-Accept: ' + key
   ];
 
+  if (this.req.headers['sec-websocket-protocol']){
+    headers.push('Sec-WebSocket-Protocol: '
+        + this.req.headers['sec-websocket-protocol']);
+  }
+
   try {
     this.socket.write(headers.concat('', '').join('\r\n'));
     this.socket.setTimeout(0);

--- a/lib/protocols/hybi-16.js
+++ b/lib/protocols/hybi-16.js
@@ -125,6 +125,11 @@ WebSocket.prototype.onOpen = function () {
     , 'Sec-WebSocket-Accept: ' + key
   ];
 
+  if (this.req.headers['sec-websocket-protocol']){
+    headers.push('Sec-WebSocket-Protocol: '
+        + this.req.headers['sec-websocket-protocol']);
+  }
+
   try {
     this.socket.write(headers.concat('', '').join('\r\n'));
     this.socket.setTimeout(0);


### PR DESCRIPTION
The HyBi implementations silently discard the "sec-websocket-protocol" header sent by the client. It should be returned when the connection is established.

Also, the protocol should be exposed in the Socket object to enable the server to check for a specific protocol.
