### PR TITLE
Handle socket "timeout" event

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -37,6 +37,9 @@ function Socket (server, req) {
     .on('close', function () {
       self.onClose();
     })
+    .on('timeout', function() {
+      self.destroy();
+    })
 
   this.open = true;
   this.onOpen();


### PR DESCRIPTION
In some cases, a socket throws the "timeout" event (even though setTimeout(0) prevents timeouts). This should be handled by the server.

I don't know if "self.destroy()" is the right way to handle it, because I have seen timeouts on connections that were not "open" (so nothing is emitted to the application). Don't know if this could lead to socket leakage.
