### PR TITLE
Add 'client tracking' and 'path' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,13 @@ These are exposed by `require('websocket.io')`
     - **Parameters**
       - `Object`: optional, options object
     - **Options**
+      - `path` (`String`): If set, the server listens only on this path. By default,
+        it listens for `upgrade` events on any path.
       - `logger` (`Object`/`Boolean`): logger object. If you want to customize the
         logger options, please supply a new `Logger` object (see API below). If you
         want to enable it, set this option to `true`.
+      - `client tracking` (`Boolean`): enables client tracking (`Server.clients`). 
+        Defaults is `true`.
 - ``handleUpgrade``
     - Handles an incoming request that triggered an `upgrade` event
     - **Parameters**

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ These are exposed by `require('websocket.io')`
       - `logger` (`Object`/`Boolean`): logger object. If you want to customize the
         logger options, please supply a new `Logger` object (see API below). If you
         want to enable it, set this option to `true`.
-      - `client tracking` (`Boolean`): enables client tracking (`Server.clients`). 
+      - `clientTracking` (`Boolean`): enables client tracking (`Server.clients`).
         Defaults is `true`.
 - ``handleUpgrade``
     - Handles an incoming request that triggered an `upgrade` event

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,7 @@
 
 var protocols = require('./protocols')
   , EventEmitter = process.EventEmitter
+  , url = require('url')
   , Logger = require('./logger')
 
 /**
@@ -20,10 +21,19 @@ module.exports = Server;
  */
 
 function Server (options) {
-  this.options = options || {}
+  this.options = {
+      'path': null
+    , 'logger': new Logger()
+    , 'client tracking': true
+  };
+
+  for (var i in options) {
+    this.options[i] = options[i];
+  }
+
   this.clients = [];
   this.clientsCount = 0;
-  this.log = this.options.logger || new Logger()
+  this.log = this.options.logger;
 }
 
 /**
@@ -54,24 +64,47 @@ Server.prototype.handleUpgrade = function (req, socket, head) {
   var i = this.clients.length
     , self = this;
 
+  if (! this.checkRequest(req)) {
+    return this;
+  }
+
   // attach the legacy `head` property to request
   req.head = head;
 
   var client = this.createClient(req);
 
   if (client.open) {
-    this.clients.push(client);
-    this.clientsCount++;
+    if (this.options['client tracking']) {
+      this.clients.push(client);
+      this.clientsCount++;
 
-    client.on('close', function () {
-      self.clients[i] = null;
-      self.clientsCount--;
-    });
+      client.on('close', function () {
+        self.clients[i] = null;
+        self.clientsCount--;
+      });
+    }
 
     self.emit('connection', client);
   }
 
   return this;
+};
+
+/**
+ * Checks whether the request path matches.
+ *
+ * @return {Bool}
+ * @api private
+ */
+
+Server.prototype.checkRequest = function (req) {
+  if (this.options.path) {
+    var u = url.parse(req.url);
+    if (u && u.pathname !== this.options.path) return false;
+  }
+
+  // no options.path => match all paths
+  return true;
 };
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,9 +22,9 @@ module.exports = Server;
 
 function Server (options) {
   this.options = {
-      'path': null
-    , 'logger': new Logger()
-    , 'client tracking': true
+      path: null
+    , logger: new Logger()
+    , clientTracking: true
   };
 
   for (var i in options) {
@@ -74,7 +74,7 @@ Server.prototype.handleUpgrade = function (req, socket, head) {
   var client = this.createClient(req);
 
   if (client.open) {
-    if (this.options['client tracking']) {
+    if (this.options.clientTracking) {
       this.clients.push(client);
       this.clientsCount++;
 

--- a/test/server.js
+++ b/test/server.js
@@ -116,6 +116,44 @@ describe('websocket server', function () {
     });
   });
 
+  describe('request path', function() {
+    it('must be checked if present', function (done) {
+      listen({path: '/mypath'}, function (addr, server) {
+        var cl = client(addr, '/mypath')
+
+        cl.on('open', function () {
+          cl.close();
+          server.close();
+          done();
+        });
+      });
+    });
+
+    it('must be checked, connection rejected if not matches', function (done) {
+      listen({path: '/mypath'}, function (addr, server) {
+        var cl = client(addr, '/mypath2');
+        cl.on('open', function () {
+          cl.close();
+          server.close();
+          throw new Error('paths do not match');
+        });
+        done();
+      });
+    });
+
+    it('can be left null, so any path matches', function (done) {
+      listen(function (addr, server) {
+        var cl = client(addr, '/mypath');
+
+        cl.on('open', function () {
+          cl.close();
+          server.close();
+          done();
+        });
+      });
+    });
+  });
+
   describe('client tracking', function () {
     it('must have client objects', function (done) {
       listen(function (addr, server) {
@@ -169,6 +207,37 @@ describe('websocket server', function () {
               });
             });
           });
+        });
+      });
+    });
+
+    it('can be disabled', function (done) {
+      listen({'client tracking': false}, function (addr, server) {
+        var cl = client(addr);
+
+        cl.on('open', function () {
+          server.clients.should.have.length(0);
+          server.clientsCount.should.equal(0);
+
+          var cl2 = client(addr);
+          cl2.on('open', function () {
+            server.clients.should.have.length(0);
+            server.clientsCount.should.equal(0);
+
+            cl.close();
+            cl.on('close', function () {
+              server.clients.should.have.length(0);
+              server.clientsCount.should.equal(0);
+
+              cl2.close();
+              cl2.on('close', function () {
+                server.clients.should.have.length(0);
+                server.clientsCount.should.equal(0);
+                server.close();
+                done();
+              });
+            })
+          });          
         });
       });
     });

--- a/test/server.js
+++ b/test/server.js
@@ -212,7 +212,7 @@ describe('websocket server', function () {
     });
 
     it('can be disabled', function (done) {
-      listen({'client tracking': false}, function (addr, server) {
+      listen({'clientTracking': false}, function (addr, server) {
         var cl = client(addr);
 
         cl.on('open', function () {


### PR DESCRIPTION
With the `client tracking` option, you can disable the client tracking (Server.clients array). This improves memory usage.

The `path` options makes the server check the path, which may be useful if more than one WebSocket Server should be attached to an http.Server.
