### PR TITLE
Ignore non-WebSocket requests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -98,6 +98,13 @@ Server.prototype.handleUpgrade = function (req, socket, head) {
  */
 
 Server.prototype.checkRequest = function (req) {
+  if (!(req.method == 'GET' &&
+        req.headers['upgrade'] &&
+        req.headers.upgrade.toLowerCase() == 'websocket')) {
+    // not a valid WebSocket upgrade
+    return false;
+  }
+
   if (this.options.path) {
     var u = url.parse(req.url);
     if (u && u.pathname !== this.options.path) return false;


### PR DESCRIPTION
The WebSocket server should check whether the "Upgrade" header contains "websocket", otherwise a "drafts" instance is openend and closed directly after open.
