### PR TITLE
Disable duplicate client tracking in ws

### DIFF
--- a/lib/protocols/hybi.js
+++ b/lib/protocols/hybi.js
@@ -28,7 +28,8 @@ exports = module.exports = WebSocket;
 function WebSocket (server, req) {
   var self = this;
   this.wss = new WebSocketServer({
-    noServer: true
+      noServer: true
+    , clientTracking: false
   });
   Socket.call(this, server, req);
 };


### PR DESCRIPTION
@einaros already included the patch for disabling client tracking in ws – so the ws instance used for WebSocket.IO should not track clients.
