### PR TITLE
EventEmitter = process.EventEmitter is no longert valid for Node > 6.x

### DIFF
--- a/examples/echo/server.js
+++ b/examples/echo/server.js
@@ -48,5 +48,5 @@ ws.on('connection', function (client) {
  */
 
 server.listen(3000, function () {
-  console.error('\033[96m ∞ listening on http://127.0.0.1:3000 \033[39m');
+  console.error('\\033[96m ∞ listening on http://127.0.0.1:3000 \\033[39m');
 });

--- a/lib/protocols/drafts.js
+++ b/lib/protocols/drafts.js
@@ -9,10 +9,20 @@
  * Module requirements.
  */
 
+const semver = require('semver')
+const nodeVersion = process.version
+console.log('Node version:', nodeVersion)
+
 var Socket = require('../socket')
-  , EventEmitter = process.EventEmitter
   , crypto = require('crypto')
   , debug = require('debug')('wsio:drafts')
+
+if (semver.satisfies(nodeVersion, '>=6.0.0')) {
+  var EventEmitter = require('events')
+}
+else {
+  var EventEmitter = process.EventEmitter
+}
 
 /**
  * Export the constructor.

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,9 +3,19 @@
  * Module dependencies.
  */
 
+const semver = require('semver')
+const nodeVersion = process.version
+console.log('Node version:', nodeVersion)
+
 var protocols = require('./protocols')
-  , EventEmitter = process.EventEmitter
   , url = require('url');
+
+if (semver.satisfies(nodeVersion, '>=6.0.0')) {
+  var EventEmitter = require('events')
+}
+else {
+  var EventEmitter = process.EventEmitter
+}
 
 /**
  * Module exports.

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -3,7 +3,16 @@
  * Module dependencies.
  */
 
-var EventEmitter = process.EventEmitter
+const semver = require('semver')
+const nodeVersion = process.version
+console.log('Node version:', nodeVersion)
+
+if (semver.satisfies(nodeVersion, '>=6.0.0')) {
+  var EventEmitter = require('events')
+}
+else {
+  var EventEmitter = process.EventEmitter
+}
 
 /**
  * Module exports.

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     ]
   , "dependencies": {
         "debug": "*"
-        "dgram": "^1.0.1",
-        "semver": "^5.4.1",
-        "ws": "^3.3.2",
+        , "dgram": "^1.0.1"
+        , "semver": "^5.4.1"
+        , "ws": "^3.3.2"
   }
   , "devDependencies": {
         "mocha": "*"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     ]
   , "dependencies": {
         "debug": "*"
-        , "dgram": "^1.0.1"
         , "semver": "^5.4.1"
         , "ws": "^3.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
       , { "name": "Arnout Kazemier", "email": "info@3rd-eden.com" }
       , { "name": "Nico Kaiser", "email": "nico@kaiser.me" }
       , { "name": "Andor Goetzendorff", "email": "andor.g@mytum.de" }
+      , { "name": "Jeff Galbraith", "email": "jgalbraith@intelliviewtech.com" }
     ]
   , "dependencies": {
         "debug": "*"
-      , "ws": "0.4.20"
+        "dgram": "^1.0.1",
+        "semver": "^5.4.1",
+        "ws": "^3.3.2",
   }
   , "devDependencies": {
         "mocha": "*"


### PR DESCRIPTION
My approach to fixing this does not break any backwards compatibility for Node < 6.x. I have incorporated the "semver" library to determine if the version of Node being used should be one way or the other for event emitters.

Node < 6.x:
var EventEmitter = process.EventEmitter

Node >= 6.0.0
var EventEmitter = require('events')

I am using this in production.